### PR TITLE
refactor: use eslint 5.9+ version & add jest env

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,14 +1,12 @@
 {
     "parserOptions": {
         "sourceType": "module",
-        "ecmaFeatures": {
-            "modules": true,
-            "experimentalObjectRestSpread": true
-        }
+        "ecmaFeatures": 2018
     },
     "env": {
         "browser": true,
         "mocha": true,
+        "jest": true,
         "node": true,
         "es6": true,
         "amd": true

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/MTDP-BFE/eslint-config-bfe#readme",
   "devDependencies": {
     "cz-conventional-changelog": "^2.0.0",
-    "eslint": "^2.11.1"
+    "eslint": "^5.9.0"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
I have no detailed comparison of the rules in the 5.9+ version, and then solve the problem when encountering specific problems.